### PR TITLE
[travis] Remove upstream notifications recipients.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,5 @@ branches:
 
 notifications:
   email:
-    recipients:
-      - mkonicek@fb.com
-      - eloy@artsy.net
     on_failure: change
     on_success: change


### PR DESCRIPTION
Hi,

Please kindly remove the upstream recipients of Travis notifications from this fork, as it’s leading to a lot of noise for us.